### PR TITLE
Send logrus fields to Bugsnag as metadata.

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -53,8 +53,16 @@ func (hook *bugsnagHook) Fire(entry *logrus.Entry) error {
 		notifyErr = errors.New(entry.Message)
 	}
 
+	metadata := bugsnag.MetaData{}
+	metadata["metadata"] = make(map[string]interface{})
+	for key, val := range entry.Data {
+		if key != "error" {
+			metadata["metadata"][key] = val
+		}
+	}
+
 	errWithStack := bugsnag_errors.New(notifyErr, skipStackFrames)
-	bugsnagErr := bugsnag.Notify(errWithStack)
+	bugsnagErr := bugsnag.Notify(errWithStack, metadata)
 	if bugsnagErr != nil {
 		return ErrBugsnagSendFailed{bugsnagErr}
 	}

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -23,15 +23,20 @@ type exception struct {
 	Message    string       `json:"message"`
 	Stacktrace []stackFrame `json:"stacktrace"`
 }
+
+type event struct {
+	Exceptions []exception      `json:"exceptions"`
+	Metadata   bugsnag.MetaData `json:"metaData"`
+}
+
 type notice struct {
-	Events []struct {
-		Exceptions []exception `json:"exceptions"`
-	} `json:"events"`
+	Events []event `json:"events"`
 }
 
 func TestNoticeReceived(t *testing.T) {
-	msg := make(chan exception, 1)
-	expectedMsg := "foo"
+	c := make(chan event, 2)
+	expectedMessages := []string{"foo", "bar"}
+	expectedMetadataLen := []int{3, 0}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var notice notice
@@ -39,9 +44,9 @@ func TestNoticeReceived(t *testing.T) {
 		if err := json.Unmarshal(data, &notice); err != nil {
 			t.Error(err)
 		}
-		_ = r.Body.Close()
+		r.Body.Close()
 
-		msg <- notice.Events[0].Exceptions[0]
+		c <- notice.Events[0]
 	}))
 	defer ts.Close()
 
@@ -58,23 +63,44 @@ func TestNoticeReceived(t *testing.T) {
 	log.Hooks.Add(hook)
 
 	log.WithFields(logrus.Fields{
-		"error": errors.New(expectedMsg),
+		"error":  errors.New(expectedMessages[0]),
+		"animal": "walrus",
+		"size":   9009,
+		"omg":    true,
 	}).Error("Bugsnag will not see this string")
 
-	select {
-	case received := <-msg:
-		message := received.Message
-		if message != expectedMsg {
-			t.Errorf("Unexpected message received: %s", received)
+	err := errors.New(expectedMessages[1])
+	log.WithFields(logrus.Fields{}).Error(err)
+
+	for idx := range expectedMessages {
+		select {
+		case event := <-c:
+			exception := event.Exceptions[0]
+			if exception.Message != expectedMessages[idx] {
+				t.Errorf("Unexpected message received: got %q, expected %q", exception.Message, expectedMessages[idx])
+			}
+
+			if len(exception.Stacktrace) < 1 {
+				t.Error("Bugsnag error does not have a stack trace")
+			}
+
+			metadata, ok := event.Metadata["metadata"]
+			if !ok {
+				t.Error("Expected a Metadata field to be present in the bugsnag metadata")
+			}
+
+			if ok && len(metadata) != expectedMetadataLen[idx] {
+				t.Error("Unexpected metadata length, got %d, expected %d", len(metadata), expectedMetadataLen[idx])
+			}
+
+			topFrame := exception.Stacktrace[0]
+			if topFrame.Method != "TestNoticeReceived" {
+				t.Errorf("Unexpected method on top of call stack: got %q, expected %q", topFrame.Method,
+					"TestNoticeReceived")
+			}
+
+		case <-time.After(time.Second):
+			t.Error("Timed out; no notice received by Bugsnag API")
 		}
-		if len(received.Stacktrace) < 1 {
-			t.Error("Bugsnag error does not have a stack trace")
-		}
-		topFrame := received.Stacktrace[0]
-		if topFrame.Method != "TestNoticeReceived" {
-			t.Errorf("Unexpected method on top of call stack: '%s' (should be 'TestNoticeReceived')", topFrame.Method)
-		}
-	case <-time.After(time.Second):
-		t.Error("Timed out; no notice received by Bugsnag API")
 	}
 }


### PR DESCRIPTION
This adds all `logrus.Fields{ ... }` except for the `"error"` field as Bugsnag metadata, viewable in Bugsnag under the metadata tab.

<img width="239" alt="screen shot 2016-04-05 at 2 54 33 pm" src="https://cloud.githubusercontent.com/assets/2978452/14294853/0dac8182-fb41-11e5-810f-fbdcc15db2ef.png">

cc @csfrancis 