### PR TITLE
Revert to sirupsen -> Sirupsen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ logrus-bugsnag is a hook that allows [Logrus](https://github.com/sirupsen/logrus
 
 ```go
 import (
-  log "github.com/sirupsen/logrus"
+  log "github.com/Sirupsen/logrus"
   "github.com/Shopify/logrus-bugsnag"
   bugsnag "github.com/bugsnag/bugsnag-go"
 )

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -3,7 +3,7 @@ package logrus_bugsnag
 import (
 	"errors"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/bugsnag/bugsnag-go"
 	bugsnag_errors "github.com/bugsnag/bugsnag-go/errors"
 )

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/bugsnag/bugsnag-go"
 )
 


### PR DESCRIPTION
As author commented (https://github.com/sirupsen/logrus/issues/451#issuecomment-277865588), he reverted the name change https://github.com/sirupsen/logrus/commit/26809363aac4cc10d49171447009ac6bccc9c655 .

Using import path both of `github.com/logrus/sirupsen` and `github.com/logrus/Sirupsen` might occur `case-insensitive import collision` error 😭 

I checked hooks for logrus, most of them including [official Syslog hook](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go#L7) use `github.com/logrus/Sirupsen`, so I would like to standardize the naming to `Sirupsen` to avoid the error.
