### PR TITLE
Add go test CI step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,3 +44,33 @@ jobs:
 
     - name: go-tidy-check
       uses: katexochen/go-tidy-check@v1.0.2
+
+  test:
+    name: Go ${{ matrix.go-version }} test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version:
+        - 1.17.x
+        - 1.18.x
+        - 1.19.x
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3.3.0
+
+    - name: Setup go
+      uses: actions/setup-go@v3.5.0
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache
+      uses: actions/cache@v3.2.3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Test
+      run: go test -v -race ./...

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -2,6 +2,8 @@ package logrus_bugsnag
 
 import (
 	"errors"
+	"runtime"
+	"strings"
 
 	"github.com/bugsnag/bugsnag-go/v2"
 	bugsnag_errors "github.com/bugsnag/bugsnag-go/v2/errors"
@@ -39,9 +41,6 @@ func NewBugsnagHook() (*Hook, error) {
 	return &Hook{}, nil
 }
 
-// skipStackFrames skips logrus stack frames before logging to Bugsnag.
-const skipStackFrames = 4
-
 // Fire forwards an error to Bugsnag. Given a logrus.Entry, it extracts the
 // "error" field (or the Message if the error isn't present) and sends it off.
 func (hook *Hook) Fire(entry *logrus.Entry) error {
@@ -61,13 +60,65 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
-	errWithStack := bugsnag_errors.New(notifyErr, skipStackFrames)
+	// if there's a panic on the stack (runtime.gopanic), assume we wanted
+	// everything right before that.  Otherwise, assume we wanted everything 5+
+	// frames up (before we got into logrus)
+	depthOfPanic := findPanic()
+	skipFrames := 0
+	if depthOfPanic != 0 {
+		skipFrames = depthOfPanic + 1
+	} else {
+		skipFrames = findLogrusExit() + 1
+	}
+
+	errWithStack := bugsnag_errors.New(notifyErr, skipFrames)
 	bugsnagErr := bugsnag.Notify(errWithStack, metadata)
 	if bugsnagErr != nil {
 		return ErrBugsnagSendFailed{bugsnagErr}
 	}
 
 	return nil
+}
+
+const goPanic = "runtime.gopanic"
+const logrusPackage = "github.com/sirupsen/logrus."
+
+func findLogrusExit() int {
+	stack := make([]uintptr, 12)
+	// skip three frames: runtime.Callers, findLogrusExit, Hook.Fire
+	nCallers := runtime.Callers(3, stack)
+	frames := runtime.CallersFrames(stack[:nCallers])
+	foundLogrus := false
+	for i := 0; ; i++ {
+		frame, more := frames.Next()
+		switch {
+		case strings.Contains(frame.Function, logrusPackage):
+			if !foundLogrus {
+				foundLogrus = true
+			}
+		case foundLogrus:
+			return i
+		case !more:
+			// Exhausted the stack, take deepest.
+			return i
+		}
+	}
+}
+
+func findPanic() int {
+	stack := make([]uintptr, 50)
+	// skip two frames: runtime.Callers + findPanic
+	nCallers := runtime.Callers(2, stack)
+	frames := runtime.CallersFrames(stack[:nCallers])
+	for i := 0; ; i++ {
+		frame, more := frames.Next()
+		if frame.Function == goPanic {
+			return i
+		}
+		if !more {
+			return 0
+		}
+	}
 }
 
 // Levels enumerates the log levels on which the error should be forwarded to

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -64,9 +64,10 @@ func TestNoticeReceived(t *testing.T) {
 			Notify:   ts.URL,
 			Sessions: ts.URL,
 		},
-		ReleaseStage: "production",
-		APIKey:       "12345678901234567890123456789012",
-		Synchronous:  true,
+		ReleaseStage:        "production",
+		APIKey:              "12345678901234567890123456789012",
+		Synchronous:         true,
+		AutoCaptureSessions: false,
 	})
 
 	log := logrus.New()

--- a/dev.yml
+++ b/dev.yml
@@ -5,6 +5,6 @@ up:
 
 commands:
   test:
-    run: go get -t ./... && go test ./...
+    run: go test -v -race ./...
   style:
     run: scripts/golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,16 @@ go 1.17
 require (
 	github.com/bugsnag/bugsnag-go/v2 v2.2.0
 	github.com/sirupsen/logrus v1.9.0
+	github.com/stretchr/testify v1.7.0
 )
 
 require (
 	github.com/bugsnag/panicwrap v1.3.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Add go test CI step
- Disable AutoCaptureSessions in tests, because it causes a data race, which isn't introduced by this package
- Fix logic to find logrus stack, a regression introduced in #16 , which didn't have CI
- Refactor tests: Remove server and test panics