### PR TITLE
Make log level configurable

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
       with:
-        version: v1.50.1
+        version: v1.64.8
 
   tidy:
     name: go mod tidy
@@ -32,10 +32,10 @@ jobs:
 
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: '^1.17.1'
+        go-version: '^1.22.3'
 
     - name: Cache
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -52,9 +52,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - 1.17.x
-        - 1.18.x
-        - 1.19.x
+        - 1.22.x
+        - 1.23.x
+        - 1.24.x
 
     steps:
     - name: Checkout
@@ -66,7 +66,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Cache
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,14 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/Shopify/logrus-bugsnag
+  depguard:
+    rules:
+      Main:
+        allow:
+        - $gostd
+        - github.com/bugsnag/bugsnag-go/v2
+        - github.com/sirupsen/logrus
+        - github.com/stretchr/testify
 
 issues:
   exclude-rules:

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -10,7 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Hook struct{}
+type Hook struct {
+	levels []logrus.Level
+}
 
 // ErrBugsnagUnconfigured is returned if NewBugsnagHook is called before
 // bugsnag.Configure. Bugsnag must be configured before the hook.
@@ -27,6 +29,17 @@ func (e ErrBugsnagSendFailed) Error() string {
 	return "failed to send error to Bugsnag: " + e.err.Error()
 }
 
+// levelsAtOrAbove returns all log levels at or above the specified minimum level.
+func levelsAtOrAbove(minLevel logrus.Level) []logrus.Level {
+	var result []logrus.Level
+	for _, level := range logrus.AllLevels {
+		if level <= minLevel {
+			result = append(result, level)
+		}
+	}
+	return result
+}
+
 // NewBugsnagHook initializes a logrus hook which sends exceptions to an
 // exception-tracking service compatible with the Bugsnag API. Before using
 // this hook, you must call bugsnag.Configure(). The returned object should be
@@ -34,11 +47,21 @@ func (e ErrBugsnagSendFailed) Error() string {
 //
 // Entries that trigger an Error, Fatal or Panic should now include an "error"
 // field to send to Bugsnag.
-func NewBugsnagHook() (*Hook, error) {
+//
+// Optionally accepts a minimum level to specify the lowest log level that should trigger the hook.
+// If no level is provided, the hook.levels remains nil and defaults to Error, Fatal, and Panic.
+func NewBugsnagHook(minLevel ...logrus.Level) (*Hook, error) {
 	if bugsnag.Config.APIKey == "" {
 		return nil, ErrBugsnagUnconfigured
 	}
-	return &Hook{}, nil
+
+	hook := &Hook{}
+	if len(minLevel) > 0 {
+		hook.levels = levelsAtOrAbove(minLevel[0])
+	}
+	// if no level provided, hook.levels remains nil
+
+	return hook, nil
 }
 
 // Fire forwards an error to Bugsnag. Given a logrus.Entry, it extracts the
@@ -122,8 +145,11 @@ func findPanic() int {
 }
 
 // Levels enumerates the log levels on which the error should be forwarded to
-// bugsnag: everything at or above the "Error" level.
+// bugsnag: everything at or above the configured level.
 func (hook *Hook) Levels() []logrus.Level {
+	if hook.levels != nil {
+		return hook.levels
+	}
 	return []logrus.Level{
 		logrus.ErrorLevel,
 		logrus.FatalLevel,

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -43,6 +43,7 @@ func init() {
 		Logger:              l,
 		AutoCaptureSessions: false,
 	})
+	//nolint:revive // config parameter is required by bugsnag API
 	bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
 		events <- event
 		return nil
@@ -143,6 +144,153 @@ func triggerError(l *logrus.Logger, err error) {
 
 func triggerPanic(l *logrus.Logger, msg string) {
 	l.WithField("foo", "bar").Panic(msg)
+}
+
+func TestNewBugsnagHookWithMinLevel(t *testing.T) {
+	l := logrus.New()
+	l.Out = io.Discard
+
+	// Create variables for levels so we can take their addresses
+	infoLevel := logrus.InfoLevel
+	errorLevel := logrus.ErrorLevel
+
+	testCases := []struct {
+		name              string
+		minLevel          *logrus.Level
+		testLevel         logrus.Level
+		shouldTrigger     bool
+		expectedLevelsLen int
+	}{
+		{
+			name:              "no min level - error should trigger",
+			minLevel:          nil,
+			testLevel:         logrus.ErrorLevel,
+			shouldTrigger:     true,
+			expectedLevelsLen: 0, // levels should be nil
+		},
+		{
+			name:              "no min level - info should not trigger",
+			minLevel:          nil,
+			testLevel:         logrus.InfoLevel,
+			shouldTrigger:     false,
+			expectedLevelsLen: 0, // levels should be nil
+		},
+		{
+			name:              "min level info - info should trigger",
+			minLevel:          &infoLevel,
+			testLevel:         logrus.InfoLevel,
+			shouldTrigger:     true,
+			expectedLevelsLen: 5, // panic, fatal, error, warn, info
+		},
+		{
+			name:              "min level info - error should trigger",
+			minLevel:          &infoLevel,
+			testLevel:         logrus.ErrorLevel,
+			shouldTrigger:     true,
+			expectedLevelsLen: 5, // panic, fatal, error, warn, info
+		},
+		{
+			name:              "min level info - debug should not trigger",
+			minLevel:          &infoLevel,
+			testLevel:         logrus.DebugLevel,
+			shouldTrigger:     false,
+			expectedLevelsLen: 5, // panic, fatal, error, warn, info
+		},
+		{
+			name:              "min level error - error should trigger",
+			minLevel:          &errorLevel,
+			testLevel:         logrus.ErrorLevel,
+			shouldTrigger:     true,
+			expectedLevelsLen: 3, // panic, fatal, error
+		},
+		{
+			name:              "min level error - warn should not trigger",
+			minLevel:          &errorLevel,
+			testLevel:         logrus.WarnLevel,
+			shouldTrigger:     false,
+			expectedLevelsLen: 3, // panic, fatal, error
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear any existing events
+			for len(events) > 0 {
+				<-events
+			}
+
+			var hook *Hook
+			var err error
+
+			if tc.minLevel == nil {
+				hook, err = NewBugsnagHook()
+			} else {
+				hook, err = NewBugsnagHook(*tc.minLevel)
+			}
+
+			assert.NoError(t, err)
+
+			// Check that levels are set correctly
+			if tc.minLevel == nil {
+				assert.Nil(t, hook.levels)
+			} else {
+				assert.Len(t, hook.levels, tc.expectedLevelsLen)
+				// Verify the hook's Levels() method returns the expected levels
+				hookLevels := hook.Levels()
+				containsTestLevel := false
+				for _, level := range hookLevels {
+					if level == tc.testLevel {
+						containsTestLevel = true
+						break
+					}
+				}
+				assert.Equal(t, tc.shouldTrigger, containsTestLevel)
+			}
+
+			// Test if the hook fires for the given level
+			logger := logrus.New()
+			logger.Out = io.Discard
+			logger.Hooks.Add(hook)
+
+			// Log at the test level
+			switch tc.testLevel {
+			case logrus.PanicLevel:
+				func() {
+					defer func() { _ = recover() }()
+					logger.WithError(errTest).Panic("test panic")
+				}()
+			case logrus.FatalLevel:
+				// Note: We can't actually test Fatal because it calls os.Exit
+				// So we'll skip this case in the test
+				return
+			case logrus.ErrorLevel:
+				logger.WithError(errTest).Error("test error")
+			case logrus.WarnLevel:
+				logger.WithError(errTest).Warn("test warn")
+			case logrus.InfoLevel:
+				logger.WithError(errTest).Info("test info")
+			case logrus.DebugLevel:
+				logger.WithError(errTest).Debug("test debug")
+			case logrus.TraceLevel:
+				logger.WithError(errTest).Trace("test trace")
+			}
+
+			// Check if event was received
+			select {
+			case event := <-events:
+				if !tc.shouldTrigger {
+					t.Errorf("Expected no event, but received: %v", event)
+				}
+				// If we expected an event, verify it's correct
+				assert.Equal(t, "*errors.errorString", event.ErrorClass)
+				assert.Equal(t, "test error", event.Message)
+			case <-time.After(100 * time.Millisecond):
+				if tc.shouldTrigger {
+					t.Error("Expected event but none received")
+				}
+			}
+		})
+	}
 }
 
 func readEvent(t *testing.T) *bugsnag.Event {

--- a/scripts/golangci-lint
+++ b/scripts/golangci-lint
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="${VERSION:-"1.50.1"}"
+VERSION="${VERSION:-"1.64.8"}"
 VERSION_TAG="v${VERSION}"
 
 INSTALLER_URL="github.com/golangci/golangci-lint/cmd/golangci-lint"


### PR DESCRIPTION
The hook is currently configured to fire for every logrus.Level above and including `Error`.
That may not be the right thing to do in all cases, and this PR introduces the possibility of passing a `logrun.Level` argument to `NewBugsnagHook` that sets the minimum level for which the hook should fire.

I.e. This would now only fire the hook for logs of level `Fatal` or above.
```
hook, err := NewBugsnagHook(logrus.FatalLevel)
```
